### PR TITLE
Core - Native javascript - Adding polyfill for safari and firefox for peer dependencies

### DIFF
--- a/sync-audio/javascript/index.html
+++ b/sync-audio/javascript/index.html
@@ -19,6 +19,9 @@
   </style>
 </head>
 <body>
+  <!-- Safari and firefox polyfill for packages peer dependencies  -->
+  <script async src="https://ga.jspm.io/npm:es-module-shims@1.7.0/dist/es-module-shims.js"></script>
+
   <script type="importmap">
     {
       "imports": {

--- a/sync-chat/javascript/index.html
+++ b/sync-chat/javascript/index.html
@@ -19,6 +19,9 @@
   </style>
 </head>
 <body>
+  <!-- Safari and firefox polyfill for packages peer dependencies  -->
+  <script async src="https://ga.jspm.io/npm:es-module-shims@1.7.0/dist/es-module-shims.js"></script>
+
   <script type="importmap">
     {
       "imports": {


### PR DESCRIPTION
In order for the native samples to work properly on safari and firefox, we added the importmap polyfill to the examples